### PR TITLE
Add missing configuration

### DIFF
--- a/packages/actor-observe-rdf-dereference/bin/runCarlos.ts
+++ b/packages/actor-observe-rdf-dereference/bin/runCarlos.ts
@@ -58,7 +58,7 @@ import * as fs from 'fs';
         let time = console.timeEnd("time")
         // stats to collect: query	#TPs	exec time 1st sol.	#req 1st sol	exec. time	#req	#triples received	result size	timeout?
       // Print stats to stdout
-      console.log('Query results\tHTTP requests\tProcessed quads\tExecution time');
+      console.log('Query results\tHTTP requests (from rdf-dereference bus)\tProcessed quads\tHTTP requests (from http bus)');
       console.log(results + '\t' + observer.urls.length + '\t' + observer.quads + '\t' + requestsObserver.requests);
       // console.log('HTTP requests: ' + observer.urls.length);
       // console.log('Processed quads: ' + observer.quads);

--- a/packages/actor-observe-rdf-dereference/bin/runCarlos.ts
+++ b/packages/actor-observe-rdf-dereference/bin/runCarlos.ts
@@ -32,7 +32,7 @@ import * as fs from 'fs';
   const { engine, observer, requestsObserver }: { engine: ActorInitSparql, observer: MyActionObserverRdfDereference, requestsObserver: ActionObserverHttp } = runner.collectActors({
     engine: 'urn:comunica:sparqlinit', // The SPARQL engine instance. The value is the IRI of the SPARQL init actor: https://github.com/comunica/comunica/blob/master/packages/actor-init-sparql/config/sets/sparql-init.json
     observer: 'urn:observer:my', // Our observer instance. The value is the IRI that we gave it in config/sets/rdf-dereference-observer.json
-    requestsObserver: 'urn:comunica:my',
+    requestsObserver: 'urn:httpobserver:my',
   });
 
   // Execute a SPARQL query using our engine.
@@ -49,7 +49,6 @@ import * as fs from 'fs';
 
   // Handle the query results in a streaming manner
   let results: number = 0;
-  let httpObserver: ActionObserverHttp;
 
   // query	#TPs	exec time 1st sol.	#req 1st sol	exec. time	#req	#triples received	result size	timeout?
   result.bindingsStream.on('data', (data) => results++);
@@ -60,7 +59,7 @@ import * as fs from 'fs';
         // stats to collect: query	#TPs	exec time 1st sol.	#req 1st sol	exec. time	#req	#triples received	result size	timeout?
       // Print stats to stdout
       console.log('Query results\tHTTP requests\tProcessed quads\tExecution time');
-      console.log(results + '\t' + observer.urls.length + '\t' + observer.quads + '\t' + httpObserver.requests);
+      console.log(results + '\t' + observer.urls.length + '\t' + observer.quads + '\t' + requestsObserver.requests);
       // console.log('HTTP requests: ' + observer.urls.length);
       // console.log('Processed quads: ' + observer.quads);
       // console.timeEnd("time");

--- a/packages/actor-observe-rdf-dereference/components/ActionObserver/Http/My.jsonld
+++ b/packages/actor-observe-rdf-dereference/components/ActionObserver/Http/My.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/example-actor-rdf-dereference/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-http/^1.0.0/components/context.jsonld"
+  ],
+  "@id": "npmd:example-actor-rdf-dereference",
+  "components": [
+    {
+      "@id": "ex:ActionObserver/Http/Main",
+      "@type": "Class",
+      "extends": "cc:ActionObserver",
+      "requireElement": "ActionObserverHttp",
+      "comment": "Observes HTTP actions",
+      "parameters": [
+        {
+          "@id": "cc:ActionObserver/bus",
+          "defaultScoped": {
+            "defaultScope": "ex:ActionObserver/Http/Main",
+            "defaultScopedValue": { "@id": "cbh:Bus/Http" }
+          }
+        }
+      ],
+      "constructorArguments": [
+        {
+          "extends": "cc:ActionObserver/constructorArgumentsObject"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/actor-observe-rdf-dereference/components/ActionObserver/RdfDereference/My.jsonld
+++ b/packages/actor-observe-rdf-dereference/components/ActionObserver/RdfDereference/My.jsonld
@@ -6,7 +6,7 @@
   "@id": "npmd:example-actor-rdf-dereference",
   "components": [
     {
-      "@id": "ex:ActionObserver/Http/Stats",
+      "@id": "ex:ActionObserver/RdfDereference/Main",
       "@type": "Class",
       "extends": "cc:ActionObserver",
       "requireElement": "MyActionObserverRdfDereference",
@@ -15,7 +15,7 @@
         {
           "@id": "cc:ActionObserver/bus",
           "defaultScoped": {
-            "defaultScope": "ex:ActionObserver/Http/Stats",
+            "defaultScope": "ex:ActionObserver/RdfDereference/Main",
             "defaultScopedValue": { "@id": "cbrd:Bus/RdfDereference" }
           }
         }

--- a/packages/actor-observe-rdf-dereference/components/components.jsonld
+++ b/packages/actor-observe-rdf-dereference/components/components.jsonld
@@ -4,6 +4,7 @@
   "@type": "Module",
   "requireName": "example-actor-rdf-dereference",
   "import": [
+    "files-ex:components/ActionObserver/Http/My.jsonld",
     "files-ex:components/ActionObserver/RdfDereference/My.jsonld"
   ]
 }

--- a/packages/actor-observe-rdf-dereference/components/context.jsonld
+++ b/packages/actor-observe-rdf-dereference/components/context.jsonld
@@ -7,7 +7,8 @@
       "ex": "npmd:example-actor-rdf-dereference/",
       "files-ex": "ex:^1.0.0/",
 
-      "MyActionObserverRdfDereference": "ex:ActionObserver/Http/Stats"
+      "MyActionObserverRdfDereference": "ex:ActionObserver/Http/Stats",
+      "MyActionObserverHttp": "ex:ActionObserver/Http/Main"
     }
   ]
 }

--- a/packages/actor-observe-rdf-dereference/components/context.jsonld
+++ b/packages/actor-observe-rdf-dereference/components/context.jsonld
@@ -7,7 +7,7 @@
       "ex": "npmd:example-actor-rdf-dereference/",
       "files-ex": "ex:^1.0.0/",
 
-      "MyActionObserverRdfDereference": "ex:ActionObserver/Http/Stats",
+      "MyActionObserverRdfDereference": "ex:ActionObserver/RdfDereference/Main",
       "MyActionObserverHttp": "ex:ActionObserver/Http/Main"
     }
   ]

--- a/packages/actor-observe-rdf-dereference/config/config-default.json
+++ b/packages/actor-observe-rdf-dereference/config/config-default.json
@@ -8,6 +8,7 @@
   "@type": "Runner",
   "import": [
     "files-cais:config/config-default.json",
+    "files-ex:config/sets/http-observer.json",
     "files-ex:config/sets/rdf-deference-observer.json"
   ]
 }

--- a/packages/actor-observe-rdf-dereference/config/sets/http-observer.json
+++ b/packages/actor-observe-rdf-dereference/config/sets/http-observer.json
@@ -1,0 +1,15 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-init-sparql/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/runner/^1.0.0/components/context.jsonld",
+
+    "https://linkedsoftwaredependencies.org/bundles/npm/example-actor-rdf-dereference/^1.0.0/components/context.jsonld"
+  ],
+  "@id": "urn:comunica:my",
+  "actors": [
+    {
+      "@id": "urn:httpobserver:my",
+      "@type": "MyActionObserverHttp"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the missing semantic representation of the HTTP observer (in `components/` folder), and adds this HTTP observer into the config file (`config-default.json`)

Note that the number of HTTP requests is always the same as the number of RDF dereference actions, because each RDF dereference action always requires one HTTP request. So most probably, only one of them will be required.